### PR TITLE
Use the latest interface of `outlines-core`

### DIFF
--- a/maskbench/maskbench/outlines_engine.py
+++ b/maskbench/maskbench/outlines_engine.py
@@ -1,9 +1,7 @@
 from .engine import Engine
 import json
-from outlines.models.transformers import TransformerTokenizer
-from outlines_core.fsm.outlines_core_rs import build_regex_from_schema
-from outlines_core.fsm.guide import Write, Generate
-from outlines.fsm.guide import RegexGuide
+from outlines_core import Vocabulary, Guide, Index
+from outlines_core.json_schema import build_regex_from_schema
 
 
 class OutlinesEngine(Engine):
@@ -17,25 +15,21 @@ class OutlinesEngine(Engine):
         return "Outlines"
 
     def init(self):
-        self.outlines_tokenizer = TransformerTokenizer(self.tokenizer)
+        self.vocabulary = Vocabulary.from_pretrained(self.tokenizer.name_or_path)
 
     def compile_grammar(self, schema: dict):
         rx = build_regex_from_schema(json.dumps(schema))
-        self.guide = RegexGuide.from_regex(rx, self.outlines_tokenizer)
+        self.index = Index(rx, self.vocabulary)
+        self.guide = Guide(self.index)
 
     def reset(self):
-        self.guide_state = self.guide.initial_state
+        self.guide  = Guide(self.index)
 
     def compute_mask(self):
-        self.inst = self.guide.get_next_instruction(self.guide_state)
+        self.res = self.guide.get_tokens()
 
     def commit_token(self, t: int) -> bool:
-        ok = False
-        inst = self.inst
-        if isinstance(inst, Write):
-            ok = t in inst.tokens
-        elif isinstance(inst, Generate) and inst.tokens is not None:
-            ok = t in inst.tokens
+        ok = t in self.res
         if ok:
-            self.guide_state = self.guide.get_next_state(self.guide_state, t)
+            self.guide.advance(t)
         return ok


### PR DESCRIPTION
`jsonschemabench` is using `outlines-core<0.2.0`. The interface has changed since. This PR updates the outlines engine to use the latest interface of `outlines-core`